### PR TITLE
Microsoft.Extensions to 3.1.X due to functions

### DIFF
--- a/src/Amido.Stacks.Messaging.Azure.ServiceBus.Tests/Amido.Stacks.Messaging.Azure.ServiceBus.Tests.csproj
+++ b/src/Amido.Stacks.Messaging.Azure.ServiceBus.Tests/Amido.Stacks.Messaging.Azure.ServiceBus.Tests.csproj
@@ -11,7 +11,7 @@
 	<PackageReference Include="Amido.Stacks.Testing" Version="0.2.16" />
 	<PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />

--- a/src/Amido.Stacks.Messaging.Azure.ServiceBus/Amido.Stacks.Messaging.Azure.ServiceBus.csproj
+++ b/src/Amido.Stacks.Messaging.Azure.ServiceBus/Amido.Stacks.Messaging.Azure.ServiceBus.csproj
@@ -16,9 +16,9 @@
     <PackageReference Include="Amido.Stacks.Configuration" Version="0.2.15" />
     <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.17" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="5.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="5.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.17" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="3.1.17" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.17" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/src/Amido.Stacks.Messaging.Commands/Amido.Stacks.Messaging.Commands.csproj
+++ b/src/Amido.Stacks.Messaging.Commands/Amido.Stacks.Messaging.Commands.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
 	<PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.15" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="3.1.17" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Microsoft.Extensions to 3.1.X due to functions

📲 What

Microsoft.Extensions references must point to 3.1.X because a function using this package that targets .net core 3.1 auto-load some dependencies and errors in execution here: Could not load file or assembly 'Microsoft.Extensions.***, Version=5.0.0.0 in Azure Functions
