### PR TITLE
Remove setter for ISessionContext.SessionId

### DIFF
--- a/src/Amido.Stacks.Messaging.Azure.ServiceBus/Serializers/ISessionContext.cs
+++ b/src/Amido.Stacks.Messaging.Azure.ServiceBus/Serializers/ISessionContext.cs
@@ -2,6 +2,6 @@ namespace Amido.Stacks.Messaging.Azure.ServiceBus.Serializers
 {
     public interface ISessionContext
     {
-        string SessionId { get; set; }
+        string SessionId { get; }
     }
 }


### PR DESCRIPTION
The setter is unused and results in messier interfaces for messages that implement this interface.